### PR TITLE
Update text fields and small layout changes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ description: >
   games on modern PCs.
 baseurl:
 url: "https://xenia.jp"
-github_username:  xenia-project
+github_username:  xenia-canary
 patreon_username: xenia_project
 twitter_username: xeniaproject
 discord_invite: Q9mxZf9
@@ -44,17 +44,18 @@ navigation:
       url: https://github.com/xenia-canary/xenia-canary/wiki/roadmap
       icon: event
     - title: Compatibility
-      url: https://github.com/xenia-project/game-compatibility/issues
+      url: https://github.com/xenia-canary/game-compatibility/issues
       icon: insert_chart
+    - path: settings.md
     - path: gallery.html
   - title: Community
     pages:
     - title: Discord
       url: https://discord.gg/Q9mxZf9
       icon: message
-#    - title: /r/xenia
-#      url: https://www.reddit.com/r/xenia
-#      icon: forum
+    - title: /r/xenia
+      url: https://www.reddit.com/r/xenia
+      icon: forum
     - title: YouTube
       url: https://www.youtube.com/channel/UC6bJhkUUHE18HVG2mpbygSQ
       icon: videocam
@@ -64,20 +65,20 @@ navigation:
   - title: Development
     pages:
     - title: Building
-      url: https://github.com/xenia-project/xenia/blob/master/docs/building.md
+      url: https://github.com/xenia-canary/xenia-canary/blob/canary_experimental/docs/building.md
       icon: build
     - title: Source Code
-      url: https://github.com/xenia-project/xenia
+      url: https://github.com/xenia-canary/xenia-canary
       icon: code
     - title: Issues
-      url: https://github.com/xenia-project/xenia/issues
+      url: https://github.com/xenia-canary/xenia-canary/issues
       icon: bug_report
 #    - title: Buildbot
 #      url: https://build.xenia.jp/waterfall
 #      icon: settings_system_daydream
 
 artifacts:
-  - title: Windows 7+ x64 (Direct3D 12 or Vulkan on Windows 10, Vulkan on Windows 7+)
+  - title: Windows 10+ x64
     icon: windows
     branches:
     - name: master
@@ -86,3 +87,18 @@ artifacts:
     - name: canary
       title: canary
       download_url: "https://github.com/xenia-canary/xenia-canary-releases/releases/latest/download/xenia_canary_windows.zip"
+    - name: netplay
+      title: netplay
+      download_url: "https://github.com/AdrianCassar/xenia-canary/releases/"
+    - name: edge
+      title: edge
+      download_url: "https://github.com/has207/xenia-edge/releases/latest"
+  - title: Linux
+    icon: linux
+    branches:
+    - name: canary
+      title: canary
+      download_url: "https://github.com/xenia-canary/xenia-canary-releases/releases/latest/download/xenia_canary_linux.tar.gz"
+    - name: edge
+      title: edge
+      download_url: "https://github.com/has207/xenia-edge/releases/latest"

--- a/_config.yml
+++ b/_config.yml
@@ -53,9 +53,9 @@ navigation:
     - title: Discord
       url: https://discord.gg/Q9mxZf9
       icon: message
-    - title: /r/xenia
-      url: https://www.reddit.com/r/xenia
-      icon: forum
+#    - title: /r/xenia
+#      url: https://www.reddit.com/r/xenia
+#      icon: forum
     - title: YouTube
       url: https://www.youtube.com/channel/UC6bJhkUUHE18HVG2mpbygSQ
       icon: videocam
@@ -82,11 +82,11 @@ artifacts:
     icon: windows
     branches:
     - name: master
-      title: master
+      title: master (inactive)
       download_url: "https://github.com/xenia-project/release-builds-windows/releases/latest/download/xenia_master.zip"
     - name: canary
       title: canary
-      download_url: "https://github.com/xenia-canary/xenia-canary-releases/releases/latest/download/xenia_canary_windows.zip"
+      download_url: "https://github.com/xenia-canary/xenia-canary/releases/latest"
     - name: netplay
       title: netplay
       download_url: "https://github.com/AdrianCassar/xenia-canary/releases/"

--- a/_config.yml
+++ b/_config.yml
@@ -86,10 +86,10 @@ artifacts:
       download_url: "https://github.com/xenia-project/release-builds-windows/releases/latest/download/xenia_master.zip"
     - name: canary
       title: canary
-      download_url: "https://github.com/xenia-canary/xenia-canary/releases/latest"
+      download_url: "https://github.com/xenia-canary/xenia-canary/releases/latest/download/xenia_canary_windows.7z"
     - name: netplay
       title: netplay
-      download_url: "https://github.com/AdrianCassar/xenia-canary/releases/"
+      download_url: "https://github.com/AdrianCassar/xenia-canary/releases/latest"
     - name: edge
       title: edge
       download_url: "https://github.com/has207/xenia-edge/releases/latest"
@@ -98,7 +98,7 @@ artifacts:
     branches:
     - name: canary
       title: canary
-      download_url: "https://github.com/xenia-canary/xenia-canary-releases/releases/latest/download/xenia_canary_linux.tar.gz"
+      download_url: "https://github.com/xenia-canary/xenia-canary/releases/latest/download/xenia_canary_linux.AppImage"
     - name: edge
       title: edge
       download_url: "https://github.com/has207/xenia-edge/releases/latest"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,8 @@
       <header class="site-header mdl-layout__header mdl-color-text--white-600">
         <!--{% if page.tall_header == true %}mode="waterfall-tall"{% else %}mode="waterfall"{% endif %}-->
         <div class="mdl-layout__header-row">
-          <span class="mdl-layout-title">{{ page.title }}</span>
+          <!--<span class="mdl-layout-title">{{ page.title }}</span>-->
+		  <span class="mdl-layout-title">.</span>
           <div class="mdl-layout-spacer"></div>
           <!--
           <div class="mdl-textfield mdl-js-textfield mdl-textfield--expandable">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
         <!--{% if page.tall_header == true %}mode="waterfall-tall"{% else %}mode="waterfall"{% endif %}-->
         <div class="mdl-layout__header-row">
           <!--<span class="mdl-layout-title">{{ page.title }}</span>-->
-		  <span class="mdl-layout-title">.</span>
+          <span class="mdl-layout-title">.</span>
           <div class="mdl-layout-spacer"></div>
           <!--
           <div class="mdl-textfield mdl-js-textfield mdl-textfield--expandable">

--- a/_readme.md
+++ b/_readme.md
@@ -1,17 +1,7 @@
-* [Install Ruby 2.2+ and DevKit](https://rubyinstaller.org/downloads).
-* `gem update --system`
-* Extract DevKit
-* `ruby dk.rb init`
-* `ruby dk.rb install`
-* `gem install bundler`
-
-From the repository root:
-
-```
-bundle install
-bundle exec jekyll serve
-```
-
 Theme and such from: https://www.getmdl.io/
 
 Icons from: https://material.io/resources/icons/?style=baseline
+
+From the repository root:
+
+Follow this [guide](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll) provided by Github Docs to build locally.

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -155,7 +155,7 @@ pre {
  */
 .wrapper {
     max-width: -webkit-calc(800px - (#{$spacing-unit} * 2));
-    max-width:         calc(800px - (#{$spacing-unit} * 2));
+    max-width:         calc(900px - (#{$spacing-unit} * 2));
     margin-right: auto;
     margin-left: auto;
     padding-right: $spacing-unit;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -16,7 +16,8 @@ a {
 }
 .mdl-layout__header-row {
   background: #5FA7FF;
-  color: white;
+  color: #5FA7FF;
+  height: 30px;
 }
 .mdl-layout__header .mdl-layout__drawer-button {
   background: #5FA7FF;
@@ -26,9 +27,10 @@ a {
 .site-drawer {
   border: none;
   position: absolute;
-  top: 0;
+  top: 10;
   left: 0;
   height: 100%;
+  width: 200px;
 }
 /* iOS Safari specific workaround */
 .site-drawer .mdl-menu__container {
@@ -41,27 +43,26 @@ a {
 .site-drawer-header {
   color: #727272;
   background-color: white;
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .14), 0 3px 1px -2px rgba(0, 0, 0, .2), 0 1px 5px 0 rgba(0, 0, 0, .12);
-  height: 64px;
+  height: 60px;
   position: relative;
+  font-size: 30px;
 }
 .mdl-layout__drawer>.mdl-layout-title {
-  padding-left: 12px;
+  padding-left: 10%;
   font-weight: 500;
 }
 .site-drawer-header img {
-  width: 36px;
-  height: 36px;
+  width: 60px;
+  height: 60px;
   vertical-align: middle;
-  margin-right: 6px;
+  margin-right: 3px;
 }
 .site-drawer-subheader {
-  color: rgba(0, 0, 0, .54);
+  background-color: white;
+  color: #727272;
   padding-left: 16px;
-  height: 34px;
-  line-height: 42px;
-  border-top: 1px solid rgba(0, 0, 0, .12);
-  margin-top: 8px;
+  height: 60px;
+  line-height: 60px;
   font-weight: 500;
   font-size: 16px;
 }
@@ -69,17 +70,17 @@ a {
   flex-grow: 1;
 }
 .site-layout .site-navigation .mdl-navigation__link {
-  display: block;
+  display: flex;
   align-items: center;
-  font-weight: 500;
-  font-size: 14px;
+  font-weight: 200;
+  font-size: 16px;
   text-transform: none;
-  height: 48px;
+  height: 50px;
   border-radius: 0;
   padding: 8px 16px;
   text-align: left;
   width: 100%;
-  vertical-align: middle;
+  border: 0px;
 }
 .site-layout .site-navigation .mdl-navigation__link.selected {
   color: #5FA7FF;
@@ -312,7 +313,7 @@ td.compatibility-progress {
 
 
 #github-widget {
-  width: 400px;
+  width: 600px;
   margin-left: auto;
   margin-right: auto;
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -27,7 +27,7 @@ a {
 .site-drawer {
   border: none;
   position: absolute;
-  top: 10;
+  top: 10px;
   left: 0;
   height: 100%;
   width: 200px;
@@ -80,7 +80,7 @@ a {
   padding: 8px 16px;
   text-align: left;
   width: 100%;
-  border: 0px;
+  border: 0;
 }
 .site-layout .site-navigation .mdl-navigation__link.selected {
   color: #5FA7FF;

--- a/about.md
+++ b/about.md
@@ -5,12 +5,11 @@ icon: info
 permalink: /about/
 ---
 
-* foo
-{:toc}
+## About
 
-## System Requirements
+### System Requirements
 
-See [here](/faq/#system-requirements).
+See [here](https://github.com/xenia-canary/xenia-canary/wiki/Quickstart#system-requirements).
 
 <!--## Overview
 
@@ -41,6 +40,6 @@ games to play I'm really just hacking to have fun.
 
 ## Team
 
-Contributors can be seen [here on GitHub](https://github.com/xenia-project/xenia/graphs/contributors).
+Contributors can be seen [here](https://github.com/xenia-project/xenia/graphs/contributors) and [here](https://github.com/xenia-canary/xenia-canary/graphs/contributors?from=1%2F27%2F2024).
 
 <!--TODO: auto generate a list from API.-->

--- a/compatibility.html
+++ b/compatibility.html
@@ -4,5 +4,5 @@ title: Compatibility
 icon: insert_chart
 permalink: /compatibility/
 ---
-Redirecting to <a href="https://github.com/xenia-project/game-compatibility/issues">Compatibility Page</a>
-<meta http-equiv="Refresh" content="0; url=https://github.com/xenia-project/game-compatibility/issues">
+Redirecting to <a href="https://github.com/xenia-canary/game-compatibility/issues">Compatibility Page</a>
+<meta http-equiv="Refresh" content="0; url=https://github.com/xenia-canary/game-compatibility/issues">

--- a/download.md
+++ b/download.md
@@ -5,13 +5,12 @@ icon: file_download
 permalink: /download/
 ---
 
+<h2>Downloads</h2>
+
+Before downloading any version of Xenia below, read the [Quickstart](https://github.com/xenia-canary/xenia-canary/wiki/Quickstart) guide.
+
 {% for platform in site.artifacts %}
   {% if platform.icon == "windows" %}
-<span class="icon icon--windows" aria-hidden="true">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88 88">
-        <path d="m0 12.402 35.687-4.8602.0156 34.423-35.67.20313zm35.67 33.529.0277 34.453-35.67-4.9041-.002-29.78zm4.3261-39.025 47.318-6.906v41.527l-47.318.37565zm47.329 39.349-.0111 41.34-47.318-6.6784-.0663-34.739z" fill="#00adef"/>
-    </svg>
-</span>
 {{ platform.title }} branches:
   {% else %}
 {{ platform.title }} branches:
@@ -23,6 +22,10 @@ permalink: /download/
   {% endfor %}
 {% endfor %}
 
-Linux builds coming eventually...
-
 [System Requirements](https://github.com/xenia-project/xenia/wiki/Quickstart#system-requirements)
+
+<div>
+	<p>MacOS and ARM64 support are currently under development for xenia_edge.</p>
+	
+	<p style="background-color:yellow;">Xenia UWP (Xenia on Xbox Series S/X) is not made by or endorsed by the Xenia team.</p>
+</div>

--- a/download.md
+++ b/download.md
@@ -25,7 +25,7 @@ Before downloading any version of Xenia below, read the [Quickstart](https://git
 [System Requirements](https://github.com/xenia-project/xenia/wiki/Quickstart#system-requirements)
 
 <div>
-	<p>MacOS and ARM64 support are currently under development for xenia_edge.</p>
-	
-	<p style="background-color:yellow;">Xenia UWP (Xenia on Xbox Series S/X) is not made by or endorsed by the Xenia team.</p>
+    <p>MacOS and ARM64 support are currently under development for xenia_edge.</p>
+
+    <p style="background-color:yellow;">Xenia UWP (Xenia on Xbox Series S/X) is not made by or endorsed by the Xenia team.</p>
 </div>

--- a/faq.md
+++ b/faq.md
@@ -4,5 +4,5 @@ title: FAQ
 icon: help
 permalink: /faq/
 ---
-Redirecting to <a href="https://github.com/xenia-project/xenia/wiki/FAQ">FAQ Page</a>
-<meta http-equiv="Refresh" content="0; url=https://github.com/xenia-project/xenia/wiki/FAQ">
+Redirecting to <a href="https://github.com/xenia-canary/xenia-canary/wiki/FAQ">FAQ Page</a>
+<meta http-equiv="Refresh" content="0; url=https://github.com/xenia-canary/xenia-canary/wiki/FAQ">

--- a/gallery.html
+++ b/gallery.html
@@ -5,6 +5,8 @@ icon: perm_media
 permalink: /gallery/
 ---
 
+<h2>Gallery</h2>
+
 <p>
-  <iframe height="480" src="https://www.youtube.com/embed/videoseries?list=UU6bJhkUUHE18HVG2mpbygSQ" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+  <iframe height="480" width="850" src="https://www.youtube.com/embed/videoseries?list=UU6bJhkUUHE18HVG2mpbygSQ" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 </p>

--- a/index.html
+++ b/index.html
@@ -9,21 +9,47 @@ permalink: /
 ---
 
 <div class="home">
+  
+  <div>
+    <h2>Xenia Project - Xbox 360 Research Emulator</h2>
+    <p><strong>Welcome to the Xenia Project's Official Website!</strong></p>
+	  <p>  
+		The goal of this project is to develop, experiment, research, and educate on the topic of emulation of modern devices and operating systems. Xenia's development is currently split into different forks to optimize development in different areas:
+	  </p>
+  </div>
+  <div>
+	<ul>
+		<li><a href="https://github.com/xenia-project/xenia">Xenia Master:</a> the original branch started by benvanik which originated the project. Nowadays only receives sporadic updates.</li>
+		<li><a href="https://github.com/xenia-canary/xenia-canary">Xenia Canary:</a> the experimental fork maintained by the community, with nearly daily releases, additional features and game compatibility compared to Master. Also includes <a href="https://github.com/xenia-canary/game-patches">patches</a> and recommended <a href="https://github.com/A1eNaz/Xenia-Game-Settings/wiki">game settings</a> to fix potential issues in some games.</li>
+		<li><a href="https://github.com/has207/xenia-edge">Xenia Edge:</a> an even more experimental community fork dedicated to improving Vulkan renderer, GUI, Linux compatibility and future MacOS and ARM64 releases.</li>
+		<li><a href="https://github.com/AdrianCassar/xenia-canary">Xenia Netplay:</a> a fork based on Canary dedicated to implementing online multiplayer features to several games.</li>
+	</ul>
+	<p style="background-color:yellow;"><strong>Warning! This is the only official Xenia website!</strong><br> Avoid any other websites impersonating Xenia and always use the official download links provided here.</p>
+  </div>
+
+  <div class="hr"></div>
+  
+  <div>
+    <strong>Latest Releases</strong>: Available <a href="download/">here</a>.
+  </div>
+
+  <div class="hr"></div>
+  
   <div id="github-widget">
-    <div class="" data-repo="xenia-project/xenia">
+    <div class="" data-repo="xenia-canary/xenia-canary">
       <div class="github-box repo">
         <div class="github-box-title">
           <h3>
-            <a class="owner" href="https://github.com/xenia-project">xenia-project</a>/<a class="repo" href="https://github.com/xenia-project/xenia">xenia</a>
+            <a class="owner" href="https://github.com/xenia-canary">xenia-canary</a>/<a class="repo" href="https://github.com/xenia-canary/xenia-canary">xenia-canary</a>
           </h3>
           <div class="github-stats">
-            <a class="watchers" href="https://github.com/xenia-project/xenia/watchers">???</a>
-            <a class="forks" href="https://github.com/xenia-project/xenia/network/members">???</a>
+            <a class="watchers" href="https://github.com/xenia-canary/xenia-canary/watchers">???</a>
+            <a class="forks" href="https://github.com/xenia-canary/xenia-canary/network/members">???</a>
           </div>
         </div>
         <div class="github-box-content">
           <p class="description">
-            <span>Xbox 360 Emulator Research Project </span> &mdash; <a href="https://github.com/xenia-project/xenia#readme">Read More</a>
+            <span>Xenia Canary is an experimental fork of the Xenia emulator </span> &mdash; <a href="https://github.com/xenia-canary/xenia-canary#readme">Read More</a>
           </p>
           <p class="link">
             <a href="https://xenia.jp">https://xenia.jp</a>
@@ -31,7 +57,7 @@ permalink: /
         </div>
         <div class="github-box-download">
           <p class="updated" style="display:inline">
-            Latest commit to the <strong>master</strong> branch on <span class="update-date">???</span>.
+            Latest commit to the <strong>canary</strong> branch on <span class="update-date">???</span>.
           </p>
           <!--<a href="https://build.xenia.jp/waterfall" style="position: absolute; right: 10px; display: inline;">
             <img id="buildStatusImage" src="" alt="Build Status" style="min-width: 84px; height: 18px; max-width: 100%; visibility: hidden;">
@@ -42,6 +68,10 @@ permalink: /
   </div>
 
   <div class="hr"></div>
+  
+  <div>
+    <h2>Project Updates</h2>
+  </div>
 
   <ul class="post-list">
     {% for post in site.posts %}
@@ -57,20 +87,16 @@ permalink: /
 
   <div class="hr"></div>
 
+  <!--<iframe src="https://discordapp.com/widget?id=308194948048486401&theme=dark" width="350" height="400" allowtransparency="true" frameborder="0"></iframe>-->
+
   <div>
-    <strong>DISCLAIMER:</strong>
+    <h2>Disclaimer</h2>
     <strong>xenia is not for enabling illegal activity.</strong>
-    The goal of this project is to experiment, research, and educate on the
-    topic of emulation of modern devices and operating systems.
-    All information is obtained via reverse engineering of legally purchased
-    devices, games, and information made public on the internet.
+    The goal of this project is to experiment, research, and educate on the topic of emulation of modern devices and operating systems.
+    All information is obtained via reverse engineering of legally purchased devices, games, and information made public on the internet.
+	
   </div>
 
-  <div class="hr"></div>
-
-  <div>
-    <strong>Latest Release</strong>: Available <a href="download/">here</a>.
-  </div>
 </div>
 
 <script src="{{ site.baseurl }}/scripts/merged-github-underscore.js"></script>
@@ -104,7 +130,7 @@ permalink: /
 
   function fetchRepoData(callback) {
     var gh = new Github({});
-    var repoAdapter = gh.getRepo('xenia-project', 'xenia');
+    var repoAdapter = gh.getRepo('xenia-canary', 'xenia-canary');
     repoAdapter.show(function(err, repoData) {
       // Store with timestamp for expiration.
       repoData.__cache_time__ = Date.now();

--- a/index.html
+++ b/index.html
@@ -94,7 +94,6 @@ permalink: /
     <strong>xenia is not for enabling illegal activity.</strong>
     The goal of this project is to experiment, research, and educate on the topic of emulation of modern devices and operating systems.
     All information is obtained via reverse engineering of legally purchased devices, games, and information made public on the internet.
-	
   </div>
 
 </div>

--- a/index.html
+++ b/index.html
@@ -9,32 +9,32 @@ permalink: /
 ---
 
 <div class="home">
-  
+
   <div>
     <h2>Xenia Project - Xbox 360 Research Emulator</h2>
     <p><strong>Welcome to the Xenia Project's Official Website!</strong></p>
-	  <p>  
-		The goal of this project is to develop, experiment, research, and educate on the topic of emulation of modern devices and operating systems. Xenia's development is currently split into different forks to optimize development in different areas:
-	  </p>
+    <p>
+    The goal of this project is to develop, experiment, research, and educate on the topic of emulation of modern devices and operating systems. Xenia's development is currently split into different forks to optimize development in different areas:
+    </p>
   </div>
   <div>
-	<ul>
-		<li><a href="https://github.com/xenia-project/xenia">Xenia Master:</a> the original branch started by benvanik which originated the project. Nowadays only receives sporadic updates.</li>
-		<li><a href="https://github.com/xenia-canary/xenia-canary">Xenia Canary:</a> the experimental fork maintained by the community, with nearly daily releases, additional features and game compatibility compared to Master. Also includes <a href="https://github.com/xenia-canary/game-patches">patches</a> and recommended <a href="https://github.com/A1eNaz/Xenia-Game-Settings/wiki">game settings</a> to fix potential issues in some games.</li>
-		<li><a href="https://github.com/has207/xenia-edge">Xenia Edge:</a> an even more experimental community fork dedicated to improving Vulkan renderer, GUI, Linux compatibility and future MacOS and ARM64 releases.</li>
-		<li><a href="https://github.com/AdrianCassar/xenia-canary">Xenia Netplay:</a> a fork based on Canary dedicated to implementing online multiplayer features to several games.</li>
-	</ul>
-	<p style="background-color:yellow;"><strong>Warning! This is the only official Xenia website!</strong><br> Avoid any other websites impersonating Xenia and always use the official download links provided here.</p>
+  <ul>
+    <li><a href="https://github.com/xenia-project/xenia">Xenia Master:</a> the original branch started by benvanik which originated the project. Nowadays only receives sporadic updates.</li>
+    <li><a href="https://github.com/xenia-canary/xenia-canary">Xenia Canary:</a> the experimental fork maintained by the community, with nearly daily releases, additional features and game compatibility compared to Master. Also includes <a href="https://github.com/xenia-canary/game-patches">patches</a> and recommended <a href="https://github.com/A1eNaz/Xenia-Game-Settings/wiki">game settings</a> to fix potential issues in some games.</li>
+    <li><a href="https://github.com/has207/xenia-edge">Xenia Edge:</a> an even more experimental community fork dedicated to improving Vulkan renderer, GUI, Linux compatibility and future MacOS and ARM64 releases.</li>
+    <li><a href="https://github.com/AdrianCassar/xenia-canary">Xenia Netplay:</a> a fork based on Canary dedicated to implementing online multiplayer features to several games.</li>
+  </ul>
+  <p style="background-color:yellow;"><strong>Warning! This is the only official Xenia website!</strong><br> Avoid any other websites impersonating Xenia and always use the official download links provided here.</p>
   </div>
 
   <div class="hr"></div>
-  
+
   <div>
     <strong>Latest Releases</strong>: Available <a href="download/">here</a>.
   </div>
 
   <div class="hr"></div>
-  
+
   <div id="github-widget">
     <div class="" data-repo="xenia-canary/xenia-canary">
       <div class="github-box repo">

--- a/settings.md
+++ b/settings.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Settings
+icon: settings
+permalink: /settings/
+---
+
+## Settings
+
+### Game-Specific Settings
+
+Many Xbox 360 games require special settings to be emulated on xenia-canary accurately. If you are facing issues running a game, search [A1eNaz's Xenia-Game-Settings wiki](https://github.com/A1eNaz/Xenia-Game-Settings/wiki), find the game and try the recommended settings by editing the *xenia-canary.config.toml* accordingly.
+
+### Game Patches
+
+Additionally to the settings above, xenia-canary is capable of applying user-made patches to the emulated games.
+These patches provide can provide several fixes and improvements to games such as unlocked FPS, rendering fixes and others.
+Check the [game-patches repository](https://github.com/xenia-canary/game-patches) to learn more and download the available patches.

--- a/settings.md
+++ b/settings.md
@@ -11,6 +11,8 @@ permalink: /settings/
 
 Many Xbox 360 games require special settings to be emulated on xenia-canary accurately. If you are facing issues running a game, search [A1eNaz's Xenia-Game-Settings wiki](https://github.com/A1eNaz/Xenia-Game-Settings/wiki), find the game and try the recommended settings by editing the *xenia-canary.config.toml* accordingly.
 
+Also check out xenia-manager's [optimized-settings](https://github.com/xenia-manager/optimized-settings).
+
 ### Game Patches
 
 Additionally to the settings above, xenia-canary is capable of applying user-made patches to the emulated games.


### PR DESCRIPTION
This is my proposal for a small redesign of xenia.jp focusing of updating the website's content to reflect current state of xenia development.

Summary of changes:

- Sidebar
-- Increased Xenia logo and font size on sidebar header
-- Increased sidebar width
-- Removed item border
-- Aligned icons to text
-- Removed border from subheader
-- Added link to new Settings page
-- Added link to Subreddit
-- Changed links from xenia-project to xenia-canary
-- Fixed top bar text hiding behind sidebar

- Home(index)
-- Added main header with Website Title
-- Added a paragraph describing Xenia and its forks
-- Added Warning about malicious websites
-- Moved releases link
-- Changed GitHub Widget to track xenia-canary
-- Added Subheader for project updates

- About
-- Removed Table of Contents
-- Added About header
-- Added xenia-canary contributors to Team section

- Download
-- Added Download header
-- Added QuickStart link
-- Added links to netplay and edge
-- Added section and links about Linux branches
-- Added remark about MacOS, ARM and warning about UWP

- Gallery
-- Added header
-- Fixed embed width

- Settings
-- Added sections about Game-Specific Settings and Game Patches